### PR TITLE
Delete arrow from reserve form

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eslint:fix": "npx eslint \"**/*.{js,jsx}\" --fix",
     "stylelint": "npx stylelint \"**/*.{css,scss}\"",
     "stylelint:fix": "npx stylelint \"**/*.{css,scss}\" --fix",
+    "fix": "npx eslint \"**/*.{js,jsx}\" --fix && npx stylelint \"**/*.{css,scss}\" --fix",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/routes/Reserve.jsx
+++ b/src/routes/Reserve.jsx
@@ -1,4 +1,3 @@
-import { BiArrowBack } from 'react-icons/bi';
 import '../styles/Login.scss';
 import { useNavigate } from 'react-router-dom';
 import '../styles/reserve.scss';
@@ -24,9 +23,6 @@ const Reserve = () => {
   return (
     <div className="reserve-main-container">
       <div className="container">
-        <div className="login-header">
-          <BiArrowBack className="back-icon" onClick={() => navigate('/')} />
-        </div>
         <div className="login-form">
           <h3 className="subtitle text-center">RESERVE A VIDEOGAME </h3>
           <hr className="green-line" />


### PR DESCRIPTION
Hi guys, in this PR I deleted the arrow from the reserve form as suggested. I also added a new command to the package.json that could be useful for fixing linter errors. 