### PR TITLE
Fix snapshots

### DIFF
--- a/src/__tests__/components/__snapshots__/Carousel.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Carousel.test.jsx.snap
@@ -63,7 +63,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Starting date
+              Starting date:
             </span>
              
             Thursday, July 20, 2023
@@ -74,7 +74,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Finishing date
+              Finishing date:
             </span>
              
             Monday, July 31, 2023
@@ -85,7 +85,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Days
+              Days:
             </span>
              
             11
@@ -96,7 +96,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Total price
+              Total price:
             </span>
              
             $220
@@ -138,7 +138,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Starting date
+              Starting date:
             </span>
              
             Thursday, July 20, 2023
@@ -149,7 +149,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Finishing date
+              Finishing date:
             </span>
              
             Saturday, July 22, 2023
@@ -160,7 +160,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Days
+              Days:
             </span>
              
             2
@@ -171,7 +171,7 @@ exports[`Carousel > should render as expected if items are reservations 1`] = `
             <span
               class="fw-bold"
             >
-              Total price
+              Total price:
             </span>
              
             $10

--- a/src/__tests__/components/__snapshots__/Reservation.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Reservation.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`Reservation > should render as expected 1`] = `
         <span
           class="fw-bold"
         >
-          Starting date
+          Starting date:
         </span>
          
         Thursday, July 20, 2023
@@ -43,7 +43,7 @@ exports[`Reservation > should render as expected 1`] = `
         <span
           class="fw-bold"
         >
-          Finishing date
+          Finishing date:
         </span>
          
         Monday, July 31, 2023
@@ -54,7 +54,7 @@ exports[`Reservation > should render as expected 1`] = `
         <span
           class="fw-bold"
         >
-          Days
+          Days:
         </span>
          
         11
@@ -65,7 +65,7 @@ exports[`Reservation > should render as expected 1`] = `
         <span
           class="fw-bold"
         >
-          Total price
+          Total price:
         </span>
          
         $220

--- a/src/__tests__/routes/Reserve.test.jsx
+++ b/src/__tests__/routes/Reserve.test.jsx
@@ -1,9 +1,21 @@
+import { vi } from 'vitest';
 import Reserve from '../../routes/Reserve';
 import mockVideogames from '../../__mocks__/mockVideogames';
 import renderWithProviders from '../test-utils';
 
 describe('Reserve', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render as expected', () => {
+    const date = new Date('2023/07/26');
+    vi.setSystemTime(date);
+
     const { container } = renderWithProviders(<Reserve />, {
       preloadedState: {
         videogames: {

--- a/src/__tests__/routes/__snapshots__/MyReservations.test.jsx.snap
+++ b/src/__tests__/routes/__snapshots__/MyReservations.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`MyReservations > should render as expected 1`] = `
               <span
                 class="fw-bold"
               >
-                Starting date
+                Starting date:
               </span>
                
               Thursday, July 20, 2023
@@ -83,7 +83,7 @@ exports[`MyReservations > should render as expected 1`] = `
               <span
                 class="fw-bold"
               >
-                Finishing date
+                Finishing date:
               </span>
                
               Monday, July 31, 2023
@@ -94,7 +94,7 @@ exports[`MyReservations > should render as expected 1`] = `
               <span
                 class="fw-bold"
               >
-                Days
+                Days:
               </span>
                
               11
@@ -105,7 +105,7 @@ exports[`MyReservations > should render as expected 1`] = `
               <span
                 class="fw-bold"
               >
-                Total price
+                Total price:
               </span>
                
               $220

--- a/src/__tests__/routes/__snapshots__/Reserve.test.jsx.snap
+++ b/src/__tests__/routes/__snapshots__/Reserve.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`Reserve > should render as expected 1`] = `
             </select>
             <input
               class="input"
-              min="2023-07-26"
+              min="2023-07-27"
               required=""
               type="date"
             />

--- a/src/components/ReservationDetails.jsx
+++ b/src/components/ReservationDetails.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 const ReservationDetails = ({ label, value }) => (
   <p className="mb-0">
-    <span className="fw-bold">{label}</span>
+    <span className="fw-bold">{`${label}:`}</span>
     {' '}
     {value}
   </p>

--- a/src/utils/formatToCurrency.js
+++ b/src/utils/formatToCurrency.js
@@ -1,5 +1,5 @@
 const formatToCurrency = (value, currency = 'USD') => {
-  const formatter = new Intl.NumberFormat(undefined, {
+  const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency,
     maximumSignificantDigits: 2,


### PR DESCRIPTION
**Implemented features**
- Added fake system timer to `Reserve` test
- Added missing semicolon to `ReservationDetails`
- Added `en-US` locale to `formatToCurrency`

With these changes, the snapshots won't fail on any re-run, even when running on a different machine on a different day